### PR TITLE
fix: make changed_manufacturer_data aware of multiple sources

### DIFF
--- a/src/bluetooth_sensor_state_data/__init__.py
+++ b/src/bluetooth_sensor_state_data/__init__.py
@@ -18,7 +18,9 @@ class BluetoothData(SensorData):
     def __init__(self) -> None:
         """Initialize the class."""
         super().__init__()
-        self._last_manufacturer_data_set: set[tuple[int, bytes]] = set()
+        self._last_manufacturer_data_set_by_source: dict[
+            str, set[tuple[int, bytes]]
+        ] = {}
 
     def changed_manufacturer_data(
         self, data: BluetoothServiceInfo, exclude_ids: set[int] | None = None
@@ -29,8 +31,11 @@ class BluetoothData(SensorData):
         be called once per update.
         """
         manufacturer_data = data.manufacturer_data
+        source = data.source
 
-        last_manufacturer_data_set = self._last_manufacturer_data_set
+        last_manufacturer_data_set = (
+            self._last_manufacturer_data_set_by_source.setdefault(source, set())
+        )
         if exclude_ids:
             # If there are specific manufacturer data IDs to exclude,
             # then remove them from the set of manufacturer data.
@@ -41,7 +46,7 @@ class BluetoothData(SensorData):
             }
         else:
             manufacturer_data_set = set(manufacturer_data.items())
-        self._last_manufacturer_data_set = manufacturer_data_set
+        self._last_manufacturer_data_set_by_source[source] = manufacturer_data_set
 
         if not last_manufacturer_data_set:
             # If there is no previous data and there is only one value


### PR DESCRIPTION
Every lib below is going to have to be updated to guard against multiple changes in a single update

[thermopro_ble/parser.py](https://github.com/Bluetooth-Devices/thermopro-ble/blob/ba7c6c66f977fcc589ddfa264b5122f563f021c1/src/thermopro_ble/parser.py)

[sensorpro_ble/parser.py](https://github.com/Bluetooth-Devices/sensorpro-ble/blob/854137058cff08a7def3f387d952b7d926919f21/src/sensorpro_ble/parser.py)

[inkbird_ble/parser.py](https://github.com/Bluetooth-Devices/inkbird-ble/blob/cc4fcb2f14f3ba468bc634621883a2cb688f9feb/src/inkbird_ble/parser.py)

[bluemaestro_ble/parser.py](https://github.com/Bluetooth-Devices/bluemaestro-ble/blob/a5a780f677efff245240948aa4023b120805050f/src/bluemaestro_ble/parser.py)

[tilt_ble/parser.py](https://github.com/Bluetooth-Devices/tilt-ble/blob/239857470ddd04a2e2e6aa0ef8b035ecdaf948b2/src/tilt_ble/parser.py)

[sensorpush_ble/parser.py](https://github.com/Bluetooth-Devices/sensorpush-ble/blob/574210f800ca664121078cbf6f6dd63f3ee29747/src/sensorpush_ble/parser.py)


with something like

```diff
diff --git a/src/inkbird_ble/parser.py b/src/inkbird_ble/parser.py
index c622dd4..14c2df1 100644
--- a/src/inkbird_ble/parser.py
+++ b/src/inkbird_ble/parser.py
@@ -76,7 +76,10 @@ class INKBIRDBluetoothDeviceData(BluetoothData):
         changed_manufacturer_data = self.changed_manufacturer_data(
             service_info, MANUFACTURER_DATA_ID_EXCLUDES
         )
-        if not changed_manufacturer_data:
+        if not changed_manufacturer_data or len(changed_manufacturer_data) > 1:
+            # If len(changed_manufacturer_data) > 1 it means we switched
+            # ble adapters so we do not know which data is the latest
+            # and we need to wait for the next update.
             return
 
         last_id = list(changed_manufacturer_data)[-1]
```

related issue https://github.com/home-assistant/core/issues/85432
