### PR TITLE
fix: ensure events are only kept for a single update cycle

### DIFF
--- a/src/bluetooth_sensor_state_data/__init__.py
+++ b/src/bluetooth_sensor_state_data/__init__.py
@@ -68,6 +68,10 @@ class BluetoothData(SensorData):
 
     def update(self, data: BluetoothServiceInfo) -> SensorUpdate:
         """Update a device."""
+        # Ensure events from previous
+        # updates are not carried over
+        # as events are transient.
+        self._events_updates.clear()
         self._start_update(data)
         self.update_signal_strength(data.rssi)
         return self._finish_update()


### PR DESCRIPTION
https://github.com/Bluetooth-Devices/sensor-state-data/pull/53