### PR TITLE
feat: improve change_manufacturer_data to fallback to history when raw is missing data

### DIFF
--- a/src/bluetooth_sensor_state_data/__init__.py
+++ b/src/bluetooth_sensor_state_data/__init__.py
@@ -40,12 +40,16 @@ class BluetoothData(SensorData):
             if exclude_ids:
                 # If there are specific manufacturer data IDs to exclude,
                 # then remove them from the set of manufacturer data.
-                return {
+                changed_manufacturer_data = {
                     k: v
                     for k, v in changed_manufacturer_data.items()
                     if k not in exclude_ids
                 }
-            return changed_manufacturer_data
+            # If we can't work out the changed manufacturer data
+            # fall back to the normal method.
+            if changed_manufacturer_data:
+                return changed_manufacturer_data
+
         manufacturer_data = data.manufacturer_data
         source = data.source
         last_manufacturer_data = self._last_manufacturer_data_by_source.get(source)
@@ -60,13 +64,12 @@ class BluetoothData(SensorData):
             new_manufacturer_data = manufacturer_data
 
         self._last_manufacturer_data_by_source[source] = manufacturer_data
+        single_manufacturer_data = len(new_manufacturer_data) == 1
 
-        if not last_manufacturer_data:
+        if not last_manufacturer_data or single_manufacturer_data:
             # If there is no previous data and there is only one value
             # return it
-            return (
-                new_manufacturer_data.copy() if len(new_manufacturer_data) == 1 else {}
-            )
+            return new_manufacturer_data if single_manufacturer_data else {}
 
         return dict(new_manufacturer_data.items() - last_manufacturer_data.items())
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -771,7 +771,7 @@ def test_changed_manufacturer_data_with_exclude():
     assert second_data == {1: b"\x00\x00,\x11\x00\x00m\xd3\x11\x01\x12\x01"}
 
     third_data = data.changed_manufacturer_data(SERVICE_INFO_WITH_EXCLUDE_3, {2})
-    assert third_data == {}
+    assert third_data == {1: b"\x00\x00,\x11\x00\x00m\xd3\x11\x01\x12\x01"}
 
 
 def test_changed_manufacturer_data_raw():
@@ -784,6 +784,42 @@ def test_changed_manufacturer_data_raw():
         rssi=-60,
         source="local",
         raw=b"\x06\xff\x04\x9a\xc9\xa5\x46",
+    )
+
+    data = BluetoothData()
+    assert data.changed_manufacturer_data(service_info, {2}) == {39428: b"\xc9\xa5F"}
+    assert data.changed_manufacturer_data(service_info, {39428}) == {1: b""}
+    assert data.changed_manufacturer_data(service_info) == {39428: b"\xc9\xa5F"}
+
+
+def test_changed_manufacturer_data_raw_multiple():
+    service_info = make_bluetooth_service_info(
+        name="SensorPush HT.w 0CA1",
+        manufacturer_data={1: b"", 2: b""},  # anything here
+        service_data={},
+        service_uuids=["ef090000-11d6-42ba-93b8-9dd7ec090ab0"],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        source="local",
+        raw=b"\x06\xff\x04\x9a\xc9\xa5\x46",
+    )
+
+    data = BluetoothData()
+    assert data.changed_manufacturer_data(service_info, {2}) == {39428: b"\xc9\xa5F"}
+    assert data.changed_manufacturer_data(service_info, {39428}) == {}
+    assert data.changed_manufacturer_data(service_info) == {39428: b"\xc9\xa5F"}
+
+
+def test_single_changed_manufacturer_data_raw():
+    service_info = make_bluetooth_service_info(
+        name="SensorPush HT.w 0CA1",
+        manufacturer_data={39428: b"\xc9\xa5F"},
+        service_data={},
+        service_uuids=["ef090000-11d6-42ba-93b8-9dd7ec090ab0"],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        source="local",
+        raw=b"\x06",
     )
 
     data = BluetoothData()


### PR DESCRIPTION
This can happen for passive advertising data or when the scan response is missing